### PR TITLE
body class rex-page-sprog-copy-popup nur auf sprog Seiten

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -154,9 +154,11 @@ if (rex::isBackend() && rex::getUser()) {
     |--------------------------------------------------------------------------
     */
     rex_extension::register('PAGE_BODY_ATTR', function (\rex_extension_point $ep) {
-        $subject = $ep->getSubject();
-        $subject['class'][] = 'rex-page-sprog-copy-popup';
-        $ep->setSubject($subject);
+        if (false !== strpos(\rex_be_controller::getCurrentPage(),'sprog'))  {
+            $subject = $ep->getSubject();
+            $subject['class'][] = 'rex-page-sprog-copy-popup';
+            $ep->setSubject($subject);
+        }
     });
 
     /*


### PR DESCRIPTION
Dies ist ein Vorschlag, damit die Class rex-page-sprog-copy-popup nur auf sprog Seiten zugewiesen wird.
Der Vorteil ist, dass sich damit die Seite eindeutig identifizieren lässt, um beispielsweise ein eigenes Javascript auf das Formular loszulassen.