### PR TITLE
Standard Konfiguration hinzugefügt

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -77,3 +77,7 @@ pages:
         main: true
         hasLayout: false
         hidden: true
+
+default_config:
+    wildcard_open_tag: '{{ '
+    wildcard_close_tag: ' }}'


### PR DESCRIPTION
Damit nicht erst die Konfiguration nach der Installation einmalig gespeichert werden muss, sondern die Tags sofort extern abgerufen werden können.