### PR TITLE
Option zum Kopieren von Unterartikeln hinzugefügt

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -86,6 +86,7 @@ sprog_copy_metadata = Metadaten kopieren
 sprog_copy_clang_from = von der Sprache
 sprog_copy_clang_to = zur Sprache
 sprog_copy_delete_before = Inhalte vorher löschen?
+sprog_copy_starting_article = Beginnend von Artikel ID     
 
 sprog_copy_name = Artikelname
 sprog_copy_catname = Kategoriename

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -83,6 +83,7 @@ sprog_copy_metadata = Copy metadata
 sprog_copy_clang_from = from language
 sprog_copy_clang_to = to language
 sprog_copy_delete_before = Delete content beforehand?
+sprog_copy_starting_article = Starting with article id
 
 sprog_copy_name = Article name
 sprog_copy_catname = Category name

--- a/pages/copy.structure_content.php
+++ b/pages/copy.structure_content.php
@@ -77,6 +77,16 @@ if ($func == '') {
 
     $formElements = [];
     $n = [];
+    $n['label'] = '<label for="sprog-copy-structure-content-article-id">'.$this->i18n('sprog_copy_starting_article').'</label>';
+    $n['field'] = '<input id="sprog-copy-structure-content-article-id" class="form-control" type="text" data-sprog-param="startingArticleId" name="sprog_copy_structure_content_starting_article_id" value="" />';
+    $formElements[] = $n;
+    
+    $fragment = new \rex_fragment();
+    $fragment->setVar('elements', $formElements, false);
+    $panelElements .= $fragment->parse('core/form/form.php');
+    
+    $formElements = [];
+    $n = [];
     $n['field'] = '<a class="btn btn-apply sprog-copy-button-start" href="'.rex_url::backendPage('sprog.copy.structure_content_popup', $csrfToken->getUrlParams()).'">'.$this->i18n('sprog_copy_button_start').'</a>';
     $formElements[] = $n;
 


### PR DESCRIPTION
Fügt die Option hinzu, nur Unterartikel ab einer bestimmten Artikel-ID in eine andere Sprache zu kopieren. Dies ist nützlich, falls eine Webseite neue Unterseiten erhält, welche man wieder in eine andere Sprache kopieren möchte, ohne die bereits übersetzen Seiten zu überschreiben.