### PR TITLE
Import als eigene Class. 

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -67,9 +67,8 @@ sprog_import_heading = CSV-Datei importieren
 sprog_import_missing_language_add = Sprache der Instanz hinzufügen
 sprog_import_missing_language_ignore = ignorieren
 sprog_import_missing_language_label = Wenn der Sprachcode nicht in der Instanz vorhanden ist, dann
-sprog_import_title = Import
-sprog_import_wildcard_added = {0} Platzhalter wurden hinzugefügt
-sprog_import_wildcard_updated = {0} Platzhalter wurden aktualisiert
+sprog_import_success = Der Import war erfolgreich. Details siehe System-Logdateien
+sprog_import_failed = Der Import ist fehlgeschlagen. Details siehe System-Logdateien
 
 sprog_export = Exportieren
 sprog_export_description = Hier kann man alle Platzhalter in allen Sprachen als CSV-Datei herunterladen. Nach dem Bearbeiten kann die CSV-Datei wieder importiert werden.

--- a/lib/Sprog/Import.php
+++ b/lib/Sprog/Import.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Sprog;
+
+use Symfony\Component\Serializer\Encoder\CsvEncoder;
+use rex_addon;
+use rex_file;
+use rex_clang;
+use rex_clang_service;
+use rex_sql;
+use rex;
+use rex_logger;
+use sprog\Wildcard;
+
+class Import
+{
+    private $addon;
+    private $delimiter;
+    private $missingLanguage;
+    private $logger;
+
+    public function __construct($delimiter = ';', $missingLanguage = '')
+    {
+        $this->addon = rex_addon::get('sprog');
+        $this->delimiter = $delimiter;
+        $this->missingLanguage = $missingLanguage;
+        $this->logger = rex_logger::factory();
+    }
+
+    public function importCsv($source, $isFile = true)
+    {
+        if ($isFile) {
+            if (!file_exists($source)) {
+                $this->logger->error("File not found: {$source}");
+                return false;
+            }
+
+            if (!is_readable($source)) {
+                $this->logger->error("File is not readable: {$source}");
+                return false;
+            }
+
+            $content = rex_file::get($source);
+            if ($content === false) {
+                $this->logger->error("Failed to read file: {$source}");
+                return false;
+            }
+        } else {
+            $content = $source; // Assume it's raw CSV data
+        }
+
+        // Remove BOM if present
+        $content = preg_replace('/^\xEF\xBB\xBF/', '', $content);
+
+        if (empty($content)) {
+            $this->logger->error('Empty CSV data.');
+            return false;
+        }
+
+        $decoder = new CsvEncoder();
+        try {
+            $records = $decoder->decode($content, 'csv', [
+                CsvEncoder::DELIMITER_KEY => $this->delimiter,
+            ]);
+        } catch (\Exception $e) {
+            $this->logger->error('Failed to decode CSV: ' . $e->getMessage());
+            return false;
+        }
+
+        if (empty($records)) {
+            $this->logger->error('No records found in the CSV data.');
+            return false;
+        }
+
+        return $this->processRecords($records);
+    }
+
+    private function processRecords($records)
+    {
+        $countInserts = 0;
+        $countUpdates = 0;
+
+        $headers = array_keys($records[0]);
+        $clangsExists = $this->getClangsExists();
+
+        foreach ($headers as $index => $column) {
+            if (0 === $index) {
+                continue; // wildcard column
+            }
+
+            $column = strtolower(trim($column));
+
+            if (!isset($clangsExists[$column])) {
+                if ('add' === $this->missingLanguage) {
+                    $this->addNewLanguage($column);
+                    $this->logger->info("Language '{$column}' added.");
+                } else {
+                    $this->logger->info("Language '{$column}' ignored.");
+                }
+            }
+        }
+
+        $wildcards = $this->getExistingWildcards();
+
+        foreach ($records as $record) {
+            $result = $this->processRecord($record, $clangsExists, $wildcards);
+            $countInserts += $result['inserts'];
+            $countUpdates += $result['updates'];
+        }
+
+        Wildcard::checkAllLanguagesHaveAllWildcardsAndRepairIfNecessary();
+
+        $this->logger->info("{$countInserts} wildcards added.");
+        $this->logger->info("{$countUpdates} wildcards updated.");
+
+        return true;
+    }
+
+
+
+    private function getClangsExists()
+    {
+        $clangsExists = [];
+        foreach (rex_clang::getAll() as $clang) {
+            $clangsExists[strtolower($clang->getCode())] = $clang->getId();
+        }
+        return $clangsExists;
+    }
+
+    private function addNewLanguage($code)
+    {
+        $priority = rex_clang::count() + 1;
+        rex_clang_service::addCLang($code, $code, $priority);
+        $clangs = rex_clang::getAllIds();
+        return $clangs[array_key_last($clangs)];
+    }
+
+    private function getExistingWildcards()
+    {
+        $sql = rex_sql::factory();
+        $items = $sql->getArray('SELECT id, clang_id, wildcard FROM ' . rex::getTable('sprog_wildcard'));
+        $wildcards = [];
+        foreach ($items as $item) {
+            $wildcards[$item['wildcard']][$item['clang_id']] = (int)$item['id'];
+        }
+        return $wildcards;
+    }
+
+    private function processRecord($record, $clangsExists, &$wildcards)
+    {
+        $inserts = 0;
+        $updates = 0;
+        $wildcard = $record['wildcard'];
+        unset($record['wildcard']);
+
+        foreach ($record as $clangCode => $replace) {
+            $clangCode = strtolower(trim($clangCode));
+
+            if (!isset($clangsExists[$clangCode])) {
+                continue;
+            }
+
+            $clangId = $clangsExists[$clangCode];
+
+            $sql = rex_sql::factory();
+            $sql->setTable(rex::getTable('sprog_wildcard'));
+            $sql->setValue('replace', $replace);
+
+            if (isset($wildcards[$wildcard][$clangId])) {
+                $sql->setWhere('wildcard = :wildcard AND clang_id = :clangId', ['wildcard' => $wildcard, 'clangId' => $clangId]);
+                $sql->update();
+                $updates++;
+            } else {
+                if (!isset($id)) {
+                    $id = $sql->setNewId('id');
+                }
+                $sql->setValue('id', $id);
+                $sql->setValue('clang_id', $clangId);
+                $sql->setValue('wildcard', $wildcard);
+                $sql->insert();
+                $inserts++;
+            }
+        }
+
+        return ['inserts' => $inserts, 'updates' => $updates];
+    }
+}

--- a/lib/Sprog/Import.php
+++ b/lib/Sprog/Import.php
@@ -14,12 +14,12 @@ use sprog\Wildcard;
 
 class Import
 {
-    private $addon;
-    private $delimiter;
-    private $missingLanguage;
-    private $logger;
+    private rex_addon $addon;
+    private string $delimiter;
+    private string $missingLanguage;
+    private rex_logger $logger;
 
-    public function __construct($delimiter = ';', $missingLanguage = '')
+    public function __construct(string $delimiter = ';', string $missingLanguage = '')
     {
         $this->addon = rex_addon::get('sprog');
         $this->delimiter = $delimiter;
@@ -27,7 +27,7 @@ class Import
         $this->logger = rex_logger::factory();
     }
 
-    public function importCsv($source, $isFile = true)
+    public function importCsv(string $source, bool $isFile = true): bool
     {
         if ($isFile) {
             if (!file_exists($source)) {
@@ -75,7 +75,7 @@ class Import
         return $this->processRecords($records);
     }
 
-    private function processRecords($records)
+    private function processRecords(array $records): bool
     {
         $countInserts = 0;
         $countUpdates = 0;
@@ -116,9 +116,7 @@ class Import
         return true;
     }
 
-
-
-    private function getClangsExists()
+    private function getClangsExists(): array
     {
         $clangsExists = [];
         foreach (rex_clang::getAll() as $clang) {
@@ -127,7 +125,7 @@ class Import
         return $clangsExists;
     }
 
-    private function addNewLanguage($code)
+    private function addNewLanguage(string $code): int
     {
         $priority = rex_clang::count() + 1;
         rex_clang_service::addCLang($code, $code, $priority);
@@ -135,7 +133,7 @@ class Import
         return $clangs[array_key_last($clangs)];
     }
 
-    private function getExistingWildcards()
+    private function getExistingWildcards(): array
     {
         $sql = rex_sql::factory();
         $items = $sql->getArray('SELECT id, clang_id, wildcard FROM ' . rex::getTable('sprog_wildcard'));
@@ -146,7 +144,7 @@ class Import
         return $wildcards;
     }
 
-    private function processRecord($record, $clangsExists, &$wildcards)
+    private function processRecord(array $record, array $clangsExists, array &$wildcards): array
     {
         $inserts = 0;
         $updates = 0;


### PR DESCRIPTION
Somit kann man leichter aus anderen AddOns Imports einfügen. 
Die Importseite und die deutsche Sprachdatei habe ich angepasst. 

Import eines Files: 
```php
use Project\Import;
$importer = new Import(';', 'add');
$result = $importer->importCsv(rex_path::addon('project', 'sprog/test.csv'));
```

 Import eines Strings: 
```php
 use Project\Import;
 $importer = new Sprog\Import('|', 'add');
 $importer->importCsv($csvString, false);
  ```
   
   