### PR TITLE
sortiere vor dem export

### DIFF
--- a/pages/artefact.export.php
+++ b/pages/artefact.export.php
@@ -23,7 +23,7 @@ if ($func == 'export' && !$csrfToken->isValid()) {
 } elseif ($func == 'export') {
     rex_response::cleanOutputBuffers();
     $sql = rex_sql::factory();
-    $items = $sql->getArray('SELECT `id`, `clang_id`, `wildcard`, `replace` FROM '.rex::getTable('sprog_wildcard').' ORDER BY `wildcard`');
+    $items = $sql->getArray('SELECT `id`, `clang_id`, `wildcard`, `replace` FROM '.rex::getTable('sprog_wildcard').' ORDER BY `wildcard`, `clang_id`');
 
     $rows = [];
     $data = [];


### PR DESCRIPTION
Wie in #89 von @clausbde vorgeschlagen, braucht es die Sortierung der Datensätze zusätzlich nach der clang_id.

In meinem Fall ist die Reihenfolge der clangs unterschiedlich (mal kommt englisch zuerst, mal deutsch).

![Zwischenablage-1](https://github.com/user-attachments/assets/1a30c81e-2e2e-4bd1-9f68-0d851efc6598)

Der Code der das verarbeitet, sortiert nicht.
Deshalb sind im Export dann in einer Spalte verschieden Sprachen.

![Zwischenablage-2](https://github.com/user-attachments/assets/805eb90c-50f6-4c23-b0b6-06398b8f0f8c)
